### PR TITLE
Notify the deletion of the yasm binary immediately

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -24,7 +24,7 @@ git "#{Chef::Config[:file_cache_path]}/yasm" do
 	repository node[:yasm][:git_repository]
 	reference node[:yasm][:git_revision]
 	action :sync
-	notifies :delete, "file[#{creates_yasm}]"
+	notifies :delete, "file[#{creates_yasm}]", :immediately
 end
 
 #write the flags used to compile to disk
@@ -36,7 +36,7 @@ template "#{Chef::Config[:file_cache_path]}/yasm-compiled_with_flags" do
 	variables(
 		:compile_flags => node[:yasm][:compile_flags]
 	)
-	notifies :delete, "file[#{creates_yasm}]"
+	notifies :delete, "file[#{creates_yasm}]", :immediately
 end
 
 bash "compile_yasm" do
@@ -47,5 +47,5 @@ bash "compile_yasm" do
 		./configure --prefix=#{node[:yasm][:prefix]} #{node[:yasm][:compile_flags].join(' ')}
 		make clean && make && make install
 	EOH
-	creates "#{creates_yasm}"
+	not_if {::File.exist?(creates_yasm)}
 end


### PR DESCRIPTION
If not, the delete notification is processed at the end of chef run,
and the file is deleted after a successful build.
