### PR TITLE
Add name attribute in cookbook metadata

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -1,3 +1,4 @@
+name             "yasm"
 maintainer       "Escape Studios"
 maintainer_email "dev@escapestudios.com"
 license          "MIT"


### PR DESCRIPTION
Required when uploading the cookbook with Berkshelf
