### PR TITLE
fix chef syntax error

### DIFF
--- a/recipes/source.rb
+++ b/recipes/source.rb
@@ -36,7 +36,7 @@ template "#{Chef::Config[:file_cache_path]}/yasm-compiled_with_flags" do
     variables(
         :compile_flags => node[:yasm][:compile_flags]
     )
-    notifies :delete, "file[#{creates_yasm}]", :immediately
+    notifies :delete, resources(:file => creates_yasm), :immediately
 end
 
 bash "compile_yasm" do


### PR DESCRIPTION
to get it working with amazon opsworks, which run under chef 0.96 at the moment, this fix is needed. 
Think this is the never chef syntax, but not sure. In chef's docu they use both ..
http://docs.opscode.com/resource_common_notifications.html#notifies-syntax
