### PR TITLE
Fix default recipe

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -5,9 +5,11 @@
 # Copyright (c) 2016, David Joos
 #
 
-case node['yasm']['install_method']
-when :source
+case node['yasm']['install_method'].to_s
+when 'source'
   include_recipe 'yasm::source'
-when :package
+when 'package'
   include_recipe 'yasm::package'
+else
+  raise NotImplementedError, "#{node['yasm']['install_method']} installation method is not implemented for yasm.install_method attribute"
 end


### PR DESCRIPTION
Fixes default recipe string comparison and raises when invalid install_method is found. Currently it will never match any value due to comparison of String to Symbol. Should close issue #8 
